### PR TITLE
Added hotkeys for audio mute and volume adjust

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -913,9 +913,9 @@ static void ProcessAudioBuffer(short* buffer, unsigned int samples)
 
 	if (AudioMuted)
 		memset(buffer, 0, samples * 4);
-  else
+	else
 		for (size_t i = 0; i < samples * 2; ++i)
-      buffer[i] = ZL_Math::Clamp<short>(buffer[i] * AudioVolume, -32768, 32767);
+			buffer[i] = ZL_Math::Clamp<short>(buffer[i] * AudioVolume, -32768, 32767);
 }
 
 static bool AudioMix(short* buffer, unsigned int samples, bool need_mix)


### PR DESCRIPTION
This simple feature adds 3 hotkeys:

- hotkey enable + M to toggle sound mute
- hotkey enable + page up to increase volume by 10%
- hotkey enable + page down to decrease volume by 10%

This is done by processing the sound buffer directly and it looks like it's not working under all scenarios but it's a nice start.